### PR TITLE
Add AccountType node to CreditProfile

### DIFF
--- a/lib/experian.rb
+++ b/lib/experian.rb
@@ -18,7 +18,8 @@ module Experian
   class << self
 
     attr_accessor :eai, :preamble, :op_initials, :subcode, :user, :password,
-                  :vendor_number, :risk_models, :reference_number
+                  :vendor_number, :risk_models, :reference_number, :account_type_code,
+                  :account_type_terms
     attr_accessor :test_mode, :proxy, :logger
 
     def configure

--- a/lib/experian/credit_profile/request.rb
+++ b/lib/experian/credit_profile/request.rb
@@ -29,6 +29,7 @@ module Experian
       def add_request_content(xml)
         add_subscriber(xml)
         add_primary_applicant(xml)
+        add_account_type(xml)
         add_add_ons(xml)
         add_xml_options(xml)
         add_vendor(xml)
@@ -111,6 +112,13 @@ module Experian
 
       def secondary_applicant(xml)
         # TODO --> not implemented
+      end
+
+      def add_account_type(xml)
+        xml.tag!('AccountType') do
+          xml.tag!('Type', Experian.account_type_code)
+          xml.tag!('Terms', Experian.account_type_terms) if Experian.account_type_terms
+        end if Experian.account_type_code
       end
 
       def add_add_ons(xml)


### PR DESCRIPTION
- This node will be added conditionally on the presense of the Experian.account_type_code
attr_accessor