### PR TITLE
Dev 1891 allow incoming headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ tmp
 *.xsd
 *.xml
 .tags
+
+#vscode
+*.code-workspace

--- a/lib/experian/client.rb
+++ b/lib/experian/client.rb
@@ -1,10 +1,6 @@
 module Experian
   class Client
 
-    def mocked_uri(request)
-      request.mocked_uri(uri)
-    end
-
     def submit_request(request)
       response = post_request(request)
       validate_response(response)
@@ -48,8 +44,7 @@ module Experian
     private
 
     def post_request(request)
-      modified_uri = mocked_uri(request)
-      connection = Excon.new(modified_uri.to_s, excon_options) #request_uri is test_url, see experian.rb line 52
+      connection = Excon.new(request.mocked_uri_string(request_uri), excon_options) 
       connection.post(body: request.body, headers: request.headers)
     end
 

--- a/lib/experian/client.rb
+++ b/lib/experian/client.rb
@@ -3,16 +3,17 @@ module Experian
 
     def append_uri(request)
       uri = request_uri
-      if (request[:mocking][:enabled] && request[:mocking][:uri])
-        uri += request[:mocking][:uri]
+      puts request
+      if (request["mocking"] && request["mocking"]["enabled"] && request["mocking"]["uri"])
+        uri += request["mocking"]["uri"]
       end
       uri
     end
 
     def add_headers(request) 
       headers = request.headers || {}
-      if (request[:mocking][:enabled] && request[:mocking][:headers])
-        headers.merge!(request[:mocking][:headers])
+      if (request["mocking"] && request["mocking"]["enabled"] && request["mocking"]["headers"])
+        headers.merge!(request["mocking"]["headers"])
       else
         headers
       end

--- a/lib/experian/client.rb
+++ b/lib/experian/client.rb
@@ -44,7 +44,7 @@ module Experian
     private
 
     def post_request(request)
-      connection = Excon.new(request.mocked_uri_string(request_uri), excon_options) 
+      connection = Excon.new(request_uri.to_s << request.mocked_endpoint, excon_options)
       connection.post(body: request.body, headers: request.headers)
     end
 

--- a/lib/experian/client.rb
+++ b/lib/experian/client.rb
@@ -1,6 +1,23 @@
 module Experian
   class Client
 
+    def append_uri(request)
+      uri = request_uri
+      if (request[:mocking][:enabled] && request[:mocking][:uri])
+        uri = request[:mocking][:uri]
+      end
+      uri
+    end
+
+    def add_headers(request) 
+      headers = request.headers || {}
+      if (request[:mocking][:enabled] && request[:mocking][:headers])
+        headers.merge!(request[:mocking][:headers])
+      else
+        headers
+      end
+    end
+
     def submit_request(request)
       response = post_request(request)
       validate_response(response)
@@ -44,8 +61,10 @@ module Experian
     private
 
     def post_request(request)
-      connection = Excon.new(request_uri.to_s, excon_options)
-      connection.post(body: request.body, headers: request.headers)
+      modified_uri = append_uri(request)
+      headers = add_headers(request)
+      connection = Excon.new(modified_uri.to_s, excon_options) #request_uri is test_url, see experian.rb line 52
+      connection.post(body: request.body, headers: headers)
     end
 
     def excon_options

--- a/lib/experian/client.rb
+++ b/lib/experian/client.rb
@@ -1,22 +1,8 @@
 module Experian
   class Client
 
-    def append_uri(request)
-      uri = request_uri
-      puts request
-      if (request["mocking"] && request["mocking"]["enabled"] && request["mocking"]["uri"])
-        uri += request["mocking"]["uri"]
-      end
-      uri
-    end
-
-    def add_headers(request) 
-      headers = request.headers || {}
-      if (request["mocking"] && request["mocking"]["enabled"] && request["mocking"]["headers"])
-        headers.merge!(request["mocking"]["headers"])
-      else
-        headers
-      end
+    def mocked_uri(request)
+      request.mocked_uri(uri)
     end
 
     def submit_request(request)
@@ -62,10 +48,9 @@ module Experian
     private
 
     def post_request(request)
-      modified_uri = append_uri(request)
-      headers = add_headers(request)
+      modified_uri = mocked_uri(request)
       connection = Excon.new(modified_uri.to_s, excon_options) #request_uri is test_url, see experian.rb line 52
-      connection.post(body: request.body, headers: headers)
+      connection.post(body: request.body, headers: request.headers)
     end
 
     def excon_options

--- a/lib/experian/client.rb
+++ b/lib/experian/client.rb
@@ -4,7 +4,7 @@ module Experian
     def append_uri(request)
       uri = request_uri
       if (request[:mocking][:enabled] && request[:mocking][:uri])
-        uri = request[:mocking][:uri]
+        uri += request[:mocking][:uri]
       end
       uri
     end

--- a/lib/experian/request.rb
+++ b/lib/experian/request.rb
@@ -2,10 +2,17 @@ module Experian
   class Request
 
     attr_reader :xml
+    attr_reader :mocking 
+    attr_reader :mocked_uri
 
     def initialize(options = {})
       @options = options
       @xml = build_request
+      @isMocked = options["mocking"]["enabled"]
+    end
+
+    def mocked_uri(uri)
+      @isMocked ? uri << @options.mocking["uri"] : uri
     end
 
     def build_request

--- a/lib/experian/request.rb
+++ b/lib/experian/request.rb
@@ -2,9 +2,7 @@ module Experian
   class Request
 
     attr_reader :xml
-    attr_reader :options
     attr_reader :mocked_uri_string
-    attr_reader :isMocked
 
     def initialize(options = {})
       @options = options
@@ -20,7 +18,7 @@ module Experian
     end
 
     def mocked_uri_string(uri)
-        isMocked ? uri.to_s << mocked_endpoint : uri.to_s
+      isMocked ? uri.to_s << mocked_endpoint : uri.to_s
     end
 
     def build_request

--- a/lib/experian/request.rb
+++ b/lib/experian/request.rb
@@ -2,23 +2,19 @@ module Experian
   class Request
 
     attr_reader :xml
-    attr_reader :mocked_uri_string
+    attr_reader :mocked_endpoint
 
     def initialize(options = {})
       @options = options
       @xml = build_request
     end
 
-    def isMocked 
-      @options["mocking"]["endpoint"].length > 0
+    def mocking
+      @options[:mocking] ? @options[:mocking] : {"enabled" => false}
     end
 
     def mocked_endpoint
-      isMocked ? @options["mocking"]["endpoint"] : ""
-    end
-
-    def mocked_uri_string(uri)
-      isMocked ? uri.to_s << mocked_endpoint : uri.to_s
+      mocking["enabled"] && mocking["endpoint"].length > 0 ? mocking["endpoint"] : ""
     end
 
     def build_request

--- a/lib/experian/request.rb
+++ b/lib/experian/request.rb
@@ -2,17 +2,25 @@ module Experian
   class Request
 
     attr_reader :xml
-    attr_reader :mocking 
-    attr_reader :mocked_uri
+    attr_reader :options
+    attr_reader :mocked_uri_string
+    attr_reader :isMocked
 
     def initialize(options = {})
       @options = options
       @xml = build_request
-      @isMocked = options["mocking"]["enabled"]
     end
 
-    def mocked_uri(uri)
-      @isMocked ? uri << @options.mocking["uri"] : uri
+    def isMocked 
+      @options["mocking"]["endpoint"].length > 0
+    end
+
+    def mocked_endpoint
+      isMocked ? @options["mocking"]["endpoint"] : ""
+    end
+
+    def mocked_uri_string(uri)
+        isMocked ? uri.to_s << mocked_endpoint : uri.to_s
     end
 
     def build_request


### PR DESCRIPTION
appends a string to the request_uri, which will be empty by default, or otherwise containing whatever endpoint has been passed in. no validation besides whether a non-empty value exists. 